### PR TITLE
Fix Compatibility with Latest Dart 3.11 and Updates to CI Builds

### DIFF
--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -47,7 +47,7 @@ jobs:
 
     - uses: dart-lang/setup-dart@v1
       with:
-        sdk: 3.10.0-14.0.dev
+        sdk: 3.11.0
 
     - uses: ilammy/msvc-dev-cmd@v1
       with:

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -144,14 +144,17 @@ jobs:
       run: |
         TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
         build_android() {
-          local cc=$1 out=$2
+          local cc=$1 flags=$2 out=$3
           echo "Building $out (cc=$cc)"
           make clean
-          make -j libquickjs.so CC="$TOOLCHAIN/$cc"
+          make -j libquickjs.so \
+            CC="$TOOLCHAIN/$cc $flags" \
+            LDEXTRA="$flags"
           mv libquickjs.so ../assets/"$out"
         }
-        build_android aarch64-linux-android21-clang libquickjs-android-arm64.so
-        build_android x86_64-linux-android21-clang libquickjs-android-x64.so
+        build_android aarch64-linux-android21-clang "" libquickjs-android-arm64.so
+        build_android armv7a-linux-androideabi21-clang "-DJS_NAN_BOXING -latomic" libquickjs-android-arm.so
+        build_android x86_64-linux-android21-clang "" libquickjs-android-x64.so
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -72,10 +72,33 @@ jobs:
     - name: Build ${{ matrix.os }}-${{ matrix.arch }} host
       working-directory: lib-src
       if: ${{ matrix.os != 'linux'}}
-      env:
-        LDEXPORT: ${{ matrix.os == 'macos' && '-Wl,-headerpad_max_install_names' || '' }}
+      shell: bash
       run: |
-        make -j libquickjs.so LDFLAGS="$LDEXPORT"
+        if [[ "${{ matrix.os }}" == "windows" ]]; then
+          # Find libwinpthread.a — its location varies by MinGW distribution
+          WINPTHREAD_A=$(find /c/mingw64 -name 'libwinpthread.a' 2>/dev/null | grep -v debug | head -1)
+          echo "gcc: $(which gcc) ($(gcc --version | head -1))"
+          echo "libwinpthread.a: ${WINPTHREAD_A:-(not found)}"
+          ls /c/mingw64/lib/libwinpthread* /c/mingw64/x86_64-w64-mingw32/lib/libwinpthread* 2>/dev/null || true
+          if [ -n "$WINPTHREAD_A" ]; then
+            # ld.exe is a native Windows process: convert the MSYS2 path to a
+            # Windows path (C:/...) so ld.exe can find it via --whole-archive.
+            WINPTHREAD_A_WIN=$(cygpath -m "$WINPTHREAD_A")
+            echo "Windows path: $WINPTHREAD_A_WIN"
+            # --whole-archive ensures all pthread symbols are pulled from the static
+            # archive before gcc's implicit -lwinpthread can link the DLL import stub
+            LDFLAGS="-static-libgcc -Wl,--whole-archive,$WINPTHREAD_A_WIN,--no-whole-archive"
+          else
+            LDFLAGS="-static-libgcc"
+          fi
+        elif [[ "${{ matrix.os }}" == "macos" ]]; then
+          LDFLAGS="-Wl,-headerpad_max_install_names"
+        else
+          LDFLAGS=""
+        fi
+        make -j libquickjs.so LDFLAGS="$LDFLAGS"
+        echo "=== DLL imports after build ==="
+        objdump -p libquickjs.so | grep "DLL Name" || true
 
     - name: Rename assets
       if: ${{ matrix.os != 'windows'}}

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -35,10 +35,10 @@ jobs:
 
           - os: macos
             arch: x64
-            runner: macos-26-intel
+            runner: macos-15-intel
           - os: macos
             arch: arm64
-            runner: macos-26
+            runner: macos-15
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -72,8 +72,10 @@ jobs:
     - name: Build ${{ matrix.os }}-${{ matrix.arch }} host
       working-directory: lib-src
       if: ${{ matrix.os != 'linux'}}
+      env:
+        LDEXPORT: ${{ matrix.os == 'macos' && '-Wl,-headerpad_max_install_names' || '' }}
       run: |
-        make -j libquickjs.so
+        make -j libquickjs.so LDFLAGS="$LDEXPORT"
 
     - name: Rename assets
       if: ${{ matrix.os != 'windows'}}

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -152,7 +152,6 @@ jobs:
           mv libquickjs.so ../assets/"$out"
         }
         build_android aarch64-linux-android21-clang libquickjs-android-arm64.so
-        build_android armv7a-linux-androideabi21-clang libquickjs-android-arm.so
         build_android x86_64-linux-android21-clang libquickjs-android-x64.so
 
     - name: Upload artifacts

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -116,8 +116,7 @@ jobs:
           echo "Building $out (arch=$arch, sdk=$sdk, target=$target)"
           make clean
           make -j libquickjs.so \
-            CC="$CC" \
-            CFLAGS="-target $target -isysroot $SYSROOT -mios-version-min=13.0 -fPIC" \
+            CC="$CC -target $target -isysroot $SYSROOT -mios-version-min=13.0" \
             LDFLAGS="-target $target -isysroot $SYSROOT -mios-version-min=13.0 -Wl,-headerpad_max_install_names"
           mv libquickjs.so ../assets/"$out"
         }

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -99,8 +99,72 @@ jobs:
           assets/**
         if-no-files-found: error
 
+  build-ios:
+    runs-on: macos-15
+    steps:
+    - uses: actions/checkout@v4
+    - run: git clone https://gitee.com/lindeer/quickjs.git lib-src --depth 1 -b $(cat quickjs-version)
+    - run: mkdir assets
+
+    - name: Build iOS variants
+      working-directory: lib-src
+      run: |
+        build_ios() {
+          local arch=$1 sdk=$2 target=$3 out=$4
+          CC=$(xcrun --sdk "$sdk" --find clang)
+          SYSROOT=$(xcrun --sdk "$sdk" --show-sdk-path)
+          echo "Building $out (arch=$arch, sdk=$sdk, target=$target)"
+          make clean
+          make -j libquickjs.so \
+            CC="$CC" \
+            CFLAGS="-target $target -isysroot $SYSROOT -mios-version-min=13.0 -fPIC" \
+            LDFLAGS="-target $target -isysroot $SYSROOT -mios-version-min=13.0 -Wl,-headerpad_max_install_names"
+          mv libquickjs.so ../assets/"$out"
+        }
+        build_ios arm64 iphoneos arm64-apple-ios13.0 libquickjs-ios-arm64-iphoneos.dylib
+        build_ios arm64 iphonesimulator arm64-apple-ios13.0-simulator libquickjs-ios-arm64-iphonesimulator.dylib
+        build_ios x86_64 iphonesimulator x86_64-apple-ios13.0-simulator libquickjs-ios-x64-iphonesimulator.dylib
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: quickjs-ios
+        path: |
+          assets/**
+        if-no-files-found: error
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: git clone https://gitee.com/lindeer/quickjs.git lib-src --depth 1 -b $(cat quickjs-version)
+    - run: mkdir assets
+
+    - name: Build Android variants
+      working-directory: lib-src
+      run: |
+        TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+        build_android() {
+          local cc=$1 out=$2
+          echo "Building $out (cc=$cc)"
+          make clean
+          make -j libquickjs.so CC="$TOOLCHAIN/$cc"
+          mv libquickjs.so ../assets/"$out"
+        }
+        build_android aarch64-linux-android21-clang libquickjs-android-arm64.so
+        build_android armv7a-linux-androideabi21-clang libquickjs-android-arm.so
+        build_android x86_64-linux-android21-clang libquickjs-android-x64.so
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: quickjs-android
+        path: |
+          assets/**
+        if-no-files-found: error
+
   release:
-    needs: build
+    needs: [build, build-ios, build-android]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -143,17 +143,19 @@ jobs:
       working-directory: lib-src
       run: |
         TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+        # Patch fork bug: JSValueUnion used outside NAN_BOXING guard (line 2214)
+        sed -i 's/return (JSValue){ (JSValueUnion){ .int32 = val }, tag };/return JS_MKVAL(tag, val);/' quickjs.c
         build_android() {
-          local cc=$1 flags=$2 out=$3
+          local cc=$1 ldflags=$2 out=$3
           echo "Building $out (cc=$cc)"
           make clean
           make -j libquickjs.so \
-            CC="$TOOLCHAIN/$cc $flags" \
-            LDEXTRA="$flags"
+            CC="$TOOLCHAIN/$cc" \
+            LDFLAGS="$ldflags"
           mv libquickjs.so ../assets/"$out"
         }
         build_android aarch64-linux-android21-clang "" libquickjs-android-arm64.so
-        build_android armv7a-linux-androideabi21-clang "-DJS_NAN_BOXING -latomic" libquickjs-android-arm.so
+        build_android armv7a-linux-androideabi21-clang "-latomic" libquickjs-android-arm.so
         build_android x86_64-linux-android21-clang "" libquickjs-android-x64.so
 
     - name: Upload artifacts

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -36,10 +36,9 @@ jobs:
           - os: macos
             arch: x64
             runner: macos-13
-        exclude:
           - os: macos
             arch: arm64
-#           runner: macos-13-xlarge
+            runner: macos-latest
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/asset_build.yaml
+++ b/.github/workflows/asset_build.yaml
@@ -35,10 +35,10 @@ jobs:
 
           - os: macos
             arch: x64
-            runner: macos-13
+            runner: macos-26-intel
           - os: macos
             arch: arm64
-            runner: macos-latest
+            runner: macos-26
 
     runs-on: ${{ matrix.runner }}
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -16,6 +16,9 @@ void main(List<String> args) async {
 
 Future<void> _builder(BuildInput input, BuildOutputBuilder output) async {
   final buildConfig = input.config;
+  if (!buildConfig.buildCodeAssets) {
+    return;
+  }
   final codeConfig = buildConfig.code;
   final packageName = input.packageName;
   final outputDirectory = Directory.fromUri(input.outputDirectory);

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -20,8 +20,6 @@ Future<void> _builder(BuildInput input, BuildOutputBuilder output) async {
     return;
   }
   final codeConfig = buildConfig.code;
-  final os = codeConfig.targetOS;
-  final arch = codeConfig.targetArchitecture;
   final packageName = input.packageName;
   final outputDirectory = Directory.fromUri(input.outputDirectory);
   final file = await _download(packageName, codeConfig, outputDirectory);

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -22,12 +22,6 @@ Future<void> _builder(BuildInput input, BuildOutputBuilder output) async {
   final codeConfig = buildConfig.code;
   final os = codeConfig.targetOS;
   final arch = codeConfig.targetArchitecture;
-  if (os == OS.android && arch == Architecture.arm) {
-    throw UnsupportedError(
-      'quickjs does not support 32-bit ARM Android ($arch). '
-      'Use a 64-bit target (arm64 or x64) instead.',
-    );
-  }
   final packageName = input.packageName;
   final outputDirectory = Directory.fromUri(input.outputDirectory);
   final file = await _download(packageName, codeConfig, outputDirectory);

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -20,6 +20,14 @@ Future<void> _builder(BuildInput input, BuildOutputBuilder output) async {
     return;
   }
   final codeConfig = buildConfig.code;
+  final os = codeConfig.targetOS;
+  final arch = codeConfig.targetArchitecture;
+  if (os == OS.android && arch == Architecture.arm) {
+    throw UnsupportedError(
+      'quickjs does not support 32-bit ARM Android ($arch). '
+      'Use a 64-bit target (arm64 or x64) instead.',
+    );
+  }
   final packageName = input.packageName;
   final outputDirectory = Directory.fromUri(input.outputDirectory);
   final file = await _download(packageName, codeConfig, outputDirectory);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,12 +10,12 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  code_assets: ^0.19.0
-  hooks: ^0.19.0
+  code_assets: ^1.0.0
+  hooks: ^1.0.1
   ffi: ^2.1.3
   path: ^1.9.0
 
 dev_dependencies:
-  ffigen: ^11.0.0
-  lints: ^3.0.0
+  ffigen: ^20.1.1
+  lints: ^6.1.0
   test: ^1.24.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - js
 
 environment:
-  sdk: 3.10.0-14.0.dev
+  sdk: ^3.10.0
 
 dependencies:
   code_assets: ^0.19.0


### PR DESCRIPTION
* Updated dependencies
* Unpinned Dart
* Fixed crash in Web builds (it now properly skips the build hook)
* Fixed MacOS CI build (old runner is no longer functional)
* Added Android, iOS, and MacOS Arm CI builds

Note this line from `.github/workflows/asset_build.yaml`. It's just a temporary fix, the actual bug should be fixed at https://gitee.com/lindeer/quickjs

```
# Patch fork bug: JSValueUnion used outside NAN_BOXING guard (line 2214)
sed -i 's/return (JSValue){ (JSValueUnion){ .int32 = val }, tag };/return JS_MKVAL(tag, val);/' quickjs.c
```

Closes https://github.com/lindeer/quickjs-dart/issues/3